### PR TITLE
Update attribute-filter.xml

### DIFF
--- a/attribute-filter.xml
+++ b/attribute-filter.xml
@@ -50,7 +50,7 @@
              <Rule xsi:type="Requester" value="https://whoami.cloud.sh.edu.cn/shibboleth" />
              <Rule xsi:type="Requester" value="https://sog-test.cloud.sh.edu.cn/shibboleth" />
              <Rule xsi:type="Requester" value="https://sog-seman.cloud.sh.edu.cn/shibboleth" />
-             <Rule xsi:type="Requester" value="https://sog-zongguan.cloud.sh.edu.cn/shibboleth" />
+             <Rule xsi:type="Requester" value="https://i-sog.shec.edu.cn/shibboleth" />
              <Rule xsi:type="Requester" value="https://resource.cloud.sh.edu.cn/shibboleth" />
          </PolicyRequirementRule>
             <AttributeRule attributeID="uid" permitAny="true" />


### PR DESCRIPTION
综管平台更名为上海市教委政务信息系统统一门户，同时修改对应的sog域名。